### PR TITLE
Fixed: 'Application windows are expected to have a root view controller...'

### DIFF
--- a/Classes/Example/CalendarUIAppDelegate.m
+++ b/Classes/Example/CalendarUIAppDelegate.m
@@ -42,7 +42,7 @@
     // Override point for customization after application launch.
 
     // Add the tab bar controller's view to the window and display.
-    [window addSubview:tabBarController.view];
+    [window setRootViewController:tabBarController];
     [window makeKeyAndVisible];
 
     return YES;


### PR DESCRIPTION
Fixed: 'Application windows are expected to have a root view controller at the end of application launch'